### PR TITLE
Don't build, just upload.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,16 +1,15 @@
-FROM jeanlescure/node-awscli:latest
+FROM amazon/aws-cli:2.11.22
 
 LABEL "com.github.actions.name"="React Deploy to S3"
-LABEL "com.github.actions.description"="Build a React.js web app and sync to an AWS S3 repository"
+LABEL "com.github.actions.description"="Sync a built React application to an AWS S3 repository"
 LABEL "com.github.actions.icon"="upload-cloud"
 LABEL "com.github.actions.color"="green"
 
 LABEL version="1.1.0"
-LABEL repository="https://github.com/jeanlescure/react-deploy-to-s3-action"
-LABEL homepage="https://jeanlescure.io/"
+LABEL repository="https://github.com/oxctl/react-deploy-to-s3-action"
+LABEL homepage="https://github.com/oxctl/react-deploy-to-s3-action"
 LABEL maintainer="Jean Lescure <opensource@jeanlescure.io>"
 
-ENV PATH /github/workspace/node_modules/.bin:$PATH
 ADD entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]

--- a/README.md
+++ b/README.md
@@ -1,35 +1,24 @@
-![React](https://assets.jeanlescure.io/eooifcELx.svg)
-![arrow pointing right towards](https://assets.jeanlescure.io/eZA9H5.svg)
-![S3 Bucket](https://assets.jeanlescure.io/bJ4s8H8n.svg)
-
 # React Deploy to S3 Github Action
 
-Build a React.js web app and sync to an AWS S3 repository
-
-## Like this project? ❤️
-
-Please consider:
-
-- [Buying me a coffee](https://www.buymeacoffee.com/jeanlescure) ☕
-- Supporting me on [Patreon](https://www.patreon.com/jeanlescure) 🏆
-- Starring this repo on [Github](https://github.com/jeanlescure/react-deploy-to-s3-action) 🌟
+Sync a built React application to an AWS S3 repository.
 
 ## Usage
 
 This action runs the equivalent of this oversimplified example:
 
 ```sh
-$ yarn
-$ yarn build
-$ aws s3 sync public s3://your.website.com/
- # Optionally
-$ aws cloudfront create-invalidation --distribution-id XYZ --paths /\*
+$ aws s3 sync build s3://your.website.com/
 ```
+
+But it sets sensible cache headers so that re-deploys cause changes to get picked up.
+
+- /index.html - Cachable for 5 seconds. This is so we never hit the S3 bucket hard under high load (unlikely).
+- /static/* - Cachable forever.
+- /* - Cachable for a day.
 
 With the previous in mind:
 
-1- Make sure there is a `build` script in your `package.json`.
-2- Place in your .github/workflows directory a `.yml` similar to the following:
+ 1 - Place in your .github/workflows directory a `.yml` similar to the following:
 
 ```yml
 name: Upload Website
@@ -44,15 +33,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@main
-    - uses: jeanlescure/react-deploy-to-s3-action@main
+    - uses: oxctl/react-deploy-to-s3-action@main
       with:
         args: --acl public-read --follow-symlinks --delete
       env:
         NODE_ENV: development # optional: defaults to production
-        AWS_S3_BUCKET: ${{ secrets.AWS_S3_BUCKET }}
-        AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+        AWS_S3_BUCKET: ${{ variables.AWS_S3_BUCKET }}
+        AWS_ACCESS_KEY_ID: ${{ variables.AWS_ACCESS_KEY_ID }}
         AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-        AWS_REGION: us-west-1 # optional: defaults to us-east-1
+        AWS_REGION: eu-west-1 # optional: defaults to us-east-1
         SOURCE_DIR: bundle # optional: defaults to public
 ```
 
@@ -62,21 +51,17 @@ The following settings must be passed as environment variables as shown in the e
 Sensitive information, especially `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY`, should be
 [set as encrypted secrets](https://help.github.com/en/articles/virtual-environments-for-github-actions#creating-and-using-secrets-encrypted-variables) — otherwise, they'll be public to anyone browsing your repository's source code and CI logs.
 
-| Key | Value | Suggested Type | Required | Default |
-| ------------- | ------------- | ------------- | ------------- | ------------- |
-| `NODE_ENV` | This environment variable is commonly used by the web packager to select the appropriate variables for the environment you will deploy to | `env` | No | `production` |
-| `AWS_ACCESS_KEY_ID` | Your AWS Access Key. [More info here.](https://docs.aws.amazon.com/general/latest/gr/managing-aws-access-keys.html) | `secret env` | **Yes** | N/A |
-| `AWS_SECRET_ACCESS_KEY` | Your AWS Secret Access Key. [More info here.](https://docs.aws.amazon.com/general/latest/gr/managing-aws-access-keys.html) | `secret env` | **Yes** | N/A |
-| `AWS_S3_BUCKET` | The name of the bucket you're syncing to. For example, `jarv.is` or `my-app-releases`. | `secret env` | **Yes** | N/A |
-| `AWS_REGION` | The region where you created your bucket. Set to `us-east-1` by default. [Full list of regions here.](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-regions-availability-zones.html#concepts-available-regions) | `env` | No | `us-east-1` |
-| `AWS_S3_ENDPOINT` | The endpoint URL of the bucket you're syncing to. Can be used for [VPC scenarios](https://aws.amazon.com/blogs/aws/new-vpc-endpoint-for-amazon-s3/) or for non-AWS services using the S3 API, like [DigitalOcean Spaces](https://www.digitalocean.com/community/tools/adapting-an-existing-aws-s3-application-to-digitalocean-spaces). | `env` | No | Automatic (`s3.amazonaws.com` or AWS's region-specific equivalent) |
-| `SOURCE_DIR` | The `yarn build` output directory you wish to sync/upload to S3. | `env` | No | `public` |
-| `DEST_DIR` | The directory inside of the S3 bucket you wish to sync/upload to. For example, `my_project/assets`. Defaults to the root of the bucket. | `env` | No | `/` (root of bucket) |
-| `CLOUDFRONT_DISTRIBUTION_ID` | If you include a CloudFront Distribution Id using this variable, the action will run `aws cloudfront create-invalidation` for the wildcard path `*`, meaning it will completely flush the cache (Note: AWS considers this a single invalidation even though it affects all files in the distribution) so that the new changes synced to S3 are available immediately. | `secret env` | No | N/A |
+| Key | Value | Suggested Type | Required | Default                                                            |
+| ------------- | ------------- |----------------| ------------- |--------------------------------------------------------------------|
+| `AWS_ACCESS_KEY_ID` | Your AWS Access Key. [More info here.](https://docs.aws.amazon.com/general/latest/gr/managing-aws-access-keys.html) | `variable env` | **Yes** | N/A                                                                |
+| `AWS_SECRET_ACCESS_KEY` | Your AWS Secret Access Key. [More info here.](https://docs.aws.amazon.com/general/latest/gr/managing-aws-access-keys.html) | `secret env`   | **Yes** | N/A                                                                |
+| `AWS_S3_BUCKET` | The name of the bucket you're syncing to. For example, `jarv.is` or `my-app-releases`. | `variable env` | **Yes** | N/A                                                                |
+| `AWS_REGION` | The region where you created your bucket. Set to `us-east-1` by default. [Full list of regions here.](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-regions-availability-zones.html#concepts-available-regions) | `env`          | No | `us-east-1`                                                        |
+| `AWS_S3_ENDPOINT` | The endpoint URL of the bucket you're syncing to. Can be used for [VPC scenarios](https://aws.amazon.com/blogs/aws/new-vpc-endpoint-for-amazon-s3/) or for non-AWS services using the S3 API, like [DigitalOcean Spaces](https://www.digitalocean.com/community/tools/adapting-an-existing-aws-s3-application-to-digitalocean-spaces). | `env`          | No | Automatic (`s3.amazonaws.com` or AWS's region-specific equivalent) |
+| `SOURCE_DIR` | The build output directory you wish to sync/upload to S3. | `env`          | No | `build`                                                            |
+| `DEST_DIR` | The directory inside of the S3 bucket you wish to sync/upload to. For example, `my_project/assets`. Defaults to the root of the bucket. | `env`          | No | `/` (root of bucket)                                               |
 
 ## TROUBLESHOOTING
-
-- Errors such as `/bin/sh: react-scripts: not found` or `To import Sass files, you first need to install node-sass.` are usually caused by these or other libraries being within `devDependencies` in the `package.json`. **ALL** dependencies should be under the `dependencies` entry within `package.json`. A react application which gets pushed to S3 will be bundled with all its dependencies, there is no such thing as dependencies that are used for development vs production, all dependencies are needed to build the final package of html, js, css, etc.
 
 ## License
 

--- a/action.yml
+++ b/action.yml
@@ -1,6 +1,6 @@
 name: "React Deploy to S3"
-description: "Build a React.js web app and sync to an AWS S3 repository"
-author: jeanlescure
+description: "Sync a built React application to an AWS S3 repository"
+author: oxctl
 runs:
   using: docker
   image: Dockerfile


### PR DESCRIPTION
This switches the project to just upload files to S3. But in doing so it assumes a standard layout and sets the cache headers accordingly.